### PR TITLE
PR 28 CI failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,8 +19,6 @@ jobs:
         uses: bahmutov/npm-install@v1.1.0
       - name: Run tests
         run: yarn coverage
-        env:
-          CI: "1"
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,11 @@ jobs:
       - name: Install dependencies
         uses: bahmutov/npm-install@v1.1.0
       - name: Run tests
-        uses: paambaati/codeclimate-action@v2.6.0
+        run: yarn coverage
         env:
-          CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}
+          CI: "1"
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
         with:
-          coverageCommand: yarn coverage
-          coverageLocations: |
-            ${{github.workspace}}/coverage/lcov.info:lcov
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ${{ github.workspace }}/coverage/lcov.info

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![npm](https://img.shields.io/npm/v/stream-size)](https://www.npmjs.com/package/stream-size)
-[![Maintainability](https://api.codeclimate.com/v1/badges/ed74c7c06962544829cf/maintainability)](https://codeclimate.com/github/Sumolari/stream-size/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/ed74c7c06962544829cf/test_coverage)](https://codeclimate.com/github/Sumolari/stream-size/test_coverage)
+[![codecov](https://codecov.io/gh/Sumolari/stream-size/graph/badge.svg?token=NTFRNMCEGO)](https://codecov.io/gh/Sumolari/stream-size)
 [![NPM](https://img.shields.io/npm/l/stream-size)](https://www.npmjs.com/package/stream-size)
 
 `stream-size` is a non-destructive transformation for Node.js streams that adds a `sizeInBytes` property to your streams.


### PR DESCRIPTION
Replace Code Climate coverage reporting with Codecov due to `cc-reporter` failing with a shell syntax error.

---
<a href="https://cursor.com/background-agent?bcId=bc-dc7732c4-1300-4f9d-96f6-101e0708c459"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dc7732c4-1300-4f9d-96f6-101e0708c459"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Migrates coverage reporting from Code Climate to Codecov.
> 
> - CI: Replace `paambaati/codeclimate-action` with `codecov/codecov-action@v5`; run `yarn coverage` and upload `coverage/lcov.info` with `CODECOV_TOKEN` in `.github/workflows/test.yml`
> - Docs: Swap Code Climate badges for a Codecov badge in `README.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 026a87df7eec173680aa7f3851b547eb268194b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->